### PR TITLE
Change gunicorn workers and threads number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 EXPOSE 80
 
-CMD gunicorn --threads 4 --bind 0.0.0.0:80 manage:app
+CMD gunicorn --workers=3 --threads=3 --bind 0.0.0.0:80 manage:app


### PR DESCRIPTION
In order to better utilize quad-core CPUs, minor adjustments to gunicorn were needed.