### PR TITLE
Rollback to working version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,17 @@
 
 Flask notes app with MySQL as a backend.
 ---
+
+---
+
+[DEPRECATED]
+
+Due to the lack of time and invention of great products like [Obsidian](https://obsidian.md/), I will no longer provide maintenance or support for this product.
+
+Feel free to fork it or improve as you see fit.
+
+---
+
 Based on [this repository](https://github.com/OmkarPathak/A-Simple-Note-Taking-Web-App) but with:
 * MySQL / Aurora support (instead of local SQLite) with optional SSL/TLS
 * `strftime` was cut out along with any time-related functions

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ python-dateutil==2.6.1
 pytz==2017.2
 six==1.11.0
 Werkzeug==0.16.1
-WTForms==3.0.0a1
+WTForms==2.1 #tags are not working properly on 3.0.0a1
 sqlalchemy==1.4.23
 gunicorn==20.1.0
 mysqlclient==2.0.3


### PR DESCRIPTION
Rollback to last working version of WTForms == 2.1 to fix issue with non-persistent tags.
Also, adding deprecation note in the README file.